### PR TITLE
Fix encoding for ascii and Latin alphabet No.1

### DIFF
--- a/src/character-sets.js
+++ b/src/character-sets.js
@@ -1,6 +1,6 @@
 const asciiElement = { codeElement: 'G0',
   escapeSequence: [0x1B, 0x28, 0x42],
-  encoding: 'windows-1254',
+  encoding: 'windows-1252',
   isASCII: true,
   bytesPerCodePoint: 1 };
 
@@ -14,7 +14,7 @@ export const characterSets = {
   'ISO_IR 6': { encoding: 'utf-8' },
 
   // Latin alphabet No. 1
-  'ISO_IR 100': { encoding: 'windows-1254' },
+  'ISO_IR 100': { encoding: 'windows-1252' },
 
   // Latin alphabet No. 2
   'ISO_IR 101': { encoding: 'iso-8859-2' },
@@ -61,7 +61,7 @@ export const characterSets = {
     extension: true,
     elements: [asciiElement, { codeElement: 'G1',
       escapeSequence: [0x1B, 0x2D, 0x41],
-      encoding: 'windows-1254',
+      encoding: 'windows-1252',
       bytesPerCodePoint: 1 }]
   },
 


### PR DESCRIPTION
Hi @yagni, thank you for your great work!

I realized the encoding for Latin alphabet No.1 is not optimal.  In my investigation, `windows-1254` is compatible with ISO 8859-9, i.e. Turkish.  I think it's better to use `windows-1252` which is compatible with ISO 8859-1.